### PR TITLE
Fix PhoneField underline validation with Italian landline

### DIFF
--- a/src/Filament/Forms/Components/PhoneField.php
+++ b/src/Filament/Forms/Components/PhoneField.php
@@ -94,7 +94,6 @@ class PhoneField extends Field
                 }
 
                 $normalized = $component->normalizeState($value);
-
                 if ($component->isRequired()) {
                     if ($normalized['national'] === '') {
                         $fail(__('validation.required', ['attribute' => $component->getLabel()]));
@@ -108,7 +107,6 @@ class PhoneField extends Field
                 }
 
                 $message = $component->getPhoneValidationMessage($normalized);
-
                 if ($message !== null) {
                     $fail($message);
                 }
@@ -441,7 +439,7 @@ class PhoneField extends Field
 
                 if ($util->isValidNumber($parsed)) {
                     $e164 = $util->format($parsed, PhoneNumberFormat::E164);
-                    $national = (string) $parsed->getNationalNumber();
+                    $national = $util->format($parsed, PhoneNumberFormat::NATIONAL);
                 } elseif ($e164 === '') {
                     $e164 = PhoneCountries::dialCode($country).$national;
                 }
@@ -525,7 +523,7 @@ class PhoneField extends Field
 
             return [
                 'country' => $region,
-                'national' => (string) $parsed->getNationalNumber(),
+                'national' => $util->format($parsed, PhoneNumberFormat::NATIONAL),
                 'e164' => $util->format($parsed, PhoneNumberFormat::E164),
             ];
         } catch (NumberParseException) {


### PR DESCRIPTION
Hi!
terrific work BTW;

most italian landline phone numbers have "Leading zeros", which are known and managed by "PhoneNumberUtil";

however when state is set or parsed calling:

```php
$national = (string) $parsed->getNationalNumber()
```

will remove the leading zeros which will cause the validation to fails;

this PR will only replace

```php
$national = (string) $parsed->getNationalNumber()
```

with

```
$national = $util->format($parsed, PhoneNumberFormat::NATIONAL);
```

which instead is perfectly capable to maintain the leading zeros;

during my tests I've not encountered any issue since the inner validation will re-parse the "national" number before calling "isValidNumber":

```
if ($national !== '') {
            try {
                $util = PhoneNumberUtil::getInstance();
                $parsed = $util->parse($national, $country);

                if ($util->isValidNumber($parsed)) {
                ...
```

so even if "$national" is formatted the library will re-parse and should be safe for any country
